### PR TITLE
Dirty fix so the docs can build (hopefully)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,8 +20,8 @@ version = 4.1.0.dev1
 
 [options]
 install_requires =
-    aiohttp
     aiohttp-xmlrpc
+    aiohttp
     filelock
     importlib_resources; python_version < '3.7'
     packaging


### PR DESCRIPTION
For some weird reason, python setup.py install thinks aiohttp-xmlrp is
the same module as aiohttp. So instead of install aiohttp-xmlrp first,
we'll install aiohttp first. Hopefully this allows the docs to build.